### PR TITLE
fix(lib): update S3 client credentials handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@documenso/root",
       "version": "1.7.0-rc.2",
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/packages/lib/universal/upload/server-actions.ts
+++ b/packages/lib/universal/upload/server-actions.ts
@@ -131,22 +131,26 @@ const getS3Client = () => {
     process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID &&
     process.env.NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY;
 
-  const credentials = process.env.NEXT_PRIVATE_UPLOAD_AWS_ROLE_ARN
-    ? awsCredentialsProvider({
-        roleArn: process.env.NEXT_PRIVATE_UPLOAD_AWS_ROLE_ARN,
-      })
-    : undefined;
+  const vercelCredentials =
+    process.env.NEXT_PRIVATE_UPLOAD_AWS_ROLE_ARN && process.env.VERCEL
+      ? awsCredentialsProvider({
+          roleArn: process.env.NEXT_PRIVATE_UPLOAD_AWS_ROLE_ARN,
+        })
+      : undefined;
+
+  const credentials =
+    vercelCredentials ??
+    (hasCredentials
+      ? {
+          accessKeyId: String(process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID),
+          secretAccessKey: String(process.env.NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY),
+        }
+      : undefined);
 
   return new S3Client({
     endpoint: process.env.NEXT_PRIVATE_UPLOAD_ENDPOINT || undefined,
     forcePathStyle: process.env.NEXT_PRIVATE_UPLOAD_FORCE_PATH_STYLE === 'true',
     region: process.env.NEXT_PRIVATE_UPLOAD_REGION || 'us-east-1',
-    credentials:
-      hasCredentials || credentials
-        ? credentials ?? {
-            accessKeyId: String(process.env.NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID),
-            secretAccessKey: String(process.env.NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY),
-          }
-        : undefined,
+    credentials,
   });
 };


### PR DESCRIPTION
This commit updates the S3 client credentials handling in the `getS3Client` function. It introduces a check for the `VERCEL` environment variable and uses AWS OIDC authentication credentials if both `VERCEL` and `NEXT_PRIVATE_UPLOAD_AWS_ROLE_ARN` are present. Otherwise, it falls back to using the `NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID` and `NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY` environment variables. This change improves the flexibility and security of the S3 client authentication process.